### PR TITLE
convert strings to aliases in options.cfg for #18

### DIFF
--- a/config/lang_en.cfg
+++ b/config/lang_en.cfg
@@ -109,6 +109,9 @@ uistr_options_62 = "Upscaling"
 //audio tab
 //section 0
 uistr_options_63 = "Enable Audio"
+//section 1
 uistr_options_64 = "Sound Volume"
+//section 2
 uistr_options_65 = "Music Volume"
+//section 3
 uistr_options_66 = "Hit Confirmation"

--- a/config/lang_en.cfg
+++ b/config/lang_en.cfg
@@ -1,0 +1,114 @@
+////////////////////////////////////////////////////////////////////////////////////////
+//                                    options.cfg                                     //
+////////////////////////////////////////////////////////////////////////////////////////
+
+//"opt_ratios_assoc"
+uistr_options_ora_0 = "custom"
+//aspect ratio
+uistr_options_asp_0 = "custom"
+
+//tab names
+uistr_options_0  = "Game"
+uistr_options_1  = "Edit"
+uistr_options_2  = "Graphics"
+uistr_options_3  = "Display"
+uistr_options_4  = "Resolution"
+uistr_options_5  = "Audio"
+
+//game tab
+//section 0
+uistr_options_6  = "FOV"
+uistr_options_7  = "Sensitivity"
+uistr_options_8  = "Zoom FOV"
+uistr_options_9  = "Zoom Sensitivity"
+uistr_options_10 = "Zoom Toggle"
+uistr_options_11 = "Invert Mouse"
+uistr_options_12 = "UI Sensitivity"
+//section 1
+uistr_options_13 = "Show FPS"
+uistr_options_14 = "Show Clock"
+uistr_options_15 = "24 Hour"
+uistr_options_16 = "Seconds"
+uistr_options_17 = "Show Weapon"
+uistr_options_18 = "Bloody Screen"
+uistr_options_19 = "Blood"
+//section 2
+uistr_options_20 = "Show Dead Players"
+uistr_options_21 = "Ragdoll Velocity"
+uistr_options_22 = "Fullbright Models"
+uistr_options_fbr_0 = "off"
+uistr_options_fbr_1 = "subtle"
+uistr_options_fbr_2 = "bright"
+uistr_options_fbr_3 = "overbright"
+uistr_options_fbr_4 = "max"
+//section 3
+uistr_options_28 = "Radar"
+uistr_options_29 = "Teammates"
+uistr_options_30 = "Mini-Map"
+//section 4
+uistr_options_31 = "Scoreboard"
+uistr_options_32 = "Kills"
+uistr_options_33 = "Deaths"
+uistr_options_34 = "Score"
+uistr_options_35 = "Ping"
+uistr_options_36 = "Client#"
+uistr_options_37 = "IP:Port"
+uistr_options_38 = "Spectators"
+uistr_options_39 = "Transparent"
+
+//edit tab
+uistr_options_40 = "Shift Floatspeed"
+
+//graphics tab
+// common graphics levels
+uistr_options_g_0 = "low"
+uistr_options_g_1 = "medium"
+uistr_options_g_2 = "high"
+uistr_options_g_3 = "ultra"
+uistr_options_off = "off"
+uistr_options_41 = "Shadow Resolution"
+uistr_options_42 = "Shadow Filtering"
+uistr_options_43 = "Global Illumination"
+uistr_options_44 = "SSAO"
+uistr_options_45 = "Volumetric Lighting"
+uistr_options_46 = "Water"
+uistr_options_wtr_0 = "reflection"
+uistr_options_wtr_1 = "caustics"
+uistr_options_wtr_2 = "animation"
+uistr_options_47 = "Soft Particles"
+uistr_options_48 = "Stains"
+uistr_options_stn_0 = "instant-fade"
+uistr_options_stn_1 = "quick-fade"
+uistr_options_stn_2 = "moderate-fade"
+uistr_options_stn_3 = "slow-fade"
+uistr_options_49 = "3D Grass"
+uistr_options_gra_0 = "quick-fade"
+uistr_options_gra_1 = "moderate-fade"
+uistr_options_gra_2 = "slow-fade"
+uistr_options_gra_3 = "slower-fade"
+
+//display tab
+uistr_options_50 = "Fullscreen"
+uistr_options_51 = "Anisotropic Filtering"
+uistr_options_52 = "Morphological AA"
+uistr_options_53 = "Temporal AA"
+uistr_options_54 = "FXAA"
+uistr_options_55 = "Multisample AA"
+uistr_options_56 = "Gamma"
+uistr_options_57 = "V-sync"
+uistr_options_58 = "Tear"
+
+//resolution tab
+//section 0
+uistr_options_59 = "Aspect Ratio"
+uistr_options_60 = "Preset Resolution"
+uistr_options_61 = "Native"
+//section 1
+uistr_options_62 = "Upscaling"
+
+//audio tab
+//section 0
+uistr_options_63 = "Enable Audio"
+uistr_options_64 = "Sound Volume"
+uistr_options_65 = "Music Volume"
+uistr_options_66 = "Hit Confirmation"

--- a/config/ui.cfg
+++ b/config/ui.cfg
@@ -1,6 +1,7 @@
 // standard menu definitions
 // don't modify, add personal menus to autoexec.cfg instead
 
+exec "config/lang_en.cfg"          // Language Strings
 exec "config/ui/lib.cfg"           // UI library
 exec "config/ui/style.cfg"         // Styles
 exec "config/ui/scoreboard.cfg"    // Scoreboard

--- a/config/ui/options.cfg
+++ b/config/ui/options.cfg
@@ -74,7 +74,7 @@ UI_ratio32:9 = [
     "5120 1440"
 ]
 opt_ratios = [5:4 4:3 3:2 16:10 16:9 21:9 32:9]
-opt_ratios_assoc = (concat "custom" "custom" (looplistconcat ratio $opt_ratios [concat $ratio $ratio]))
+opt_ratios_assoc = (concat $uistr_options_ora_0 $uistr_options_ora_0 (looplistconcat ratio $opt_ratios [concat $ratio $ratio]))
 UI_findratio = [
     looplist ratio $opt_ratios [
         looplist res $[UI_ratio@ratio] [
@@ -87,12 +87,12 @@ UImenu "options" [
     showchanges 0
     uihlist 0 [
         UIvtab 0.2 (*f 0.048 6) UI_opttabs [
-            0 "Game"          []
-            1 "Edit"          []
-            2 "Graphics"      []
-            3 "Display"       []
-            4 "Resolution"    []
-            5 "Audio"         []
+            0 @uistr_options_0 []
+            1 @uistr_options_1 []
+            2 @uistr_options_2 []
+            3 @uistr_options_3 []
+            4 @uistr_options_4 []
+            5 @uistr_options_5 []
             //* "Console"       []
         ] 1
         uialign- 0 -1
@@ -106,7 +106,7 @@ UImenu "options" [
                     case $UI_opttabs 0 [//Game//////////////////////////////////////////////////////////
                         UI_optbar//----------------------------------------------------------------------
                         uitablerow [
-                            uihlist 0.01 [uifill $UI_optc1wA ; uitext "FOV" 0.6]
+                            uihlist 0.01 [uifill $UI_optc1wA ; uitext $uistr_options_6 0.6]
                             uihlist 0 [
                                 UIhslider fov 10 150 5 0.3 $UI_optrowh [uitext $fov 0.6]
                                 uifield fov 3 [] 0.65 style_generic_focus
@@ -114,7 +114,7 @@ UImenu "options" [
                             uialign* -1 0
                         ]
                         uitablerow [
-                            uihlist 0.01 [uifill $UI_optc1wA ; uitext "Sensitivity" 0.6]
+                            uihlist 0.01 [uifill $UI_optc1wA ; uitext $uistr_options_7 0.6]
                             uihlist 0 [
                                 UIhslider sensitivity 0.1 40.0 0.1 0.3 $UI_optrowh [uitext $sensitivity 0.6]
                                 uifield sensitivity 3 [] 0.65 style_generic_focus
@@ -122,7 +122,7 @@ UImenu "options" [
                             uialign* -1 0
                         ]
                         uitablerow [
-                            uihlist 0.01 [uifill $UI_optc1wA ; uitext "Zoom FOV" 0.6]
+                            uihlist 0.01 [uifill $UI_optc1wA ; uitext $uistr_options_8 0.6]
                             uihlist 0 [
                                 UIhslider zoomfov 10 90 1 0.3 $UI_optrowh [uitext $zoomfov 0.6]
                                 uifield zoomfov 3 [] 0.65 style_generic_focus
@@ -130,7 +130,7 @@ UImenu "options" [
                             uialign* -1 0
                         ]
                         uitablerow [
-                            uihlist 0.01 [uifill $UI_optc1wA ; uitext "Zoom Sensitivity" 0.6]
+                            uihlist 0.01 [uifill $UI_optc1wA ; uitext $uistr_options_9 0.6]
                             uihlist 0 [
                                 UIhslider zoomsens 0.1 20.0 0.1 0.3 $UI_optrowh [uitext $zoomsens 0.6]
                                 uifield zoomsens 3 [] 0.65 style_generic_focus
@@ -140,19 +140,19 @@ UImenu "options" [
                         uitablerow [
                             UIbutton "hold2" [
                                 UIcheckbox $zoomtoggle 0.016
-                                uitext "Zoom Toggle" 0.6
+                                uitext $uistr_options_10 0.6
                             ] $UI_optc1wB $UI_optrowh [zoomtoggle (! $zoomtoggle)] -1
                             uialign* -1 0
                         ]
                         uitablerow [
                             UIbutton "hold2" [
                                 UIcheckbox $invmouse 0.016
-                                uitext "Invert Mouse" 0.6
+                                uitext $uistr_options_11 0.6
                             ] $UI_optc1wB $UI_optrowh [invmouse (! $invmouse)] -1
                             uialign* -1 0
                         ]
                         uitablerow [
-                            uihlist 0.01 [uifill $UI_optc1wA ; uitext "UI Sensitivity" 0.6]
+                            uihlist 0.01 [uifill $UI_optc1wA ; uitext $uistr_options_12 0.6]
                             uihlist 0 [
                                 UIhslider uisensitivity 0.1 4.0 0.1 0.3 0.032 [uitext $uisensitivity 0.6]
                                 uifield uisensitivity 3 [] 0.65 style_generic_focus
@@ -163,24 +163,24 @@ UImenu "options" [
                         uitablerow [
                             UIbutton "hold2" [
                                 UIcheckbox $showfps 0.016
-                                uitext "Show FPS" 0.6
+                                uitext $uistr_options_13 0.6
                             ] $UI_optc1wB $UI_optrowh [showfps (! $showfps)] -1
                             uialign* -1 0
                         ]
                         uitablerow [
                             UIbutton "hold2" [
                                 UIcheckbox $wallclock 0.016
-                                uitext "Show Clock" 0.6
+                                uitext $uistr_options_14 0.6
                             ] $UI_optc1wB $UI_optrowh [wallclock (! $wallclock)] -1
                             uialign* -1 0
                             uihlist 0 [
                                 UIbutton "hold2" [
                                     UIcheckbox $wallclock24 0.016
-                                    uitext (concatword (? (! $wallclock) "^f4") "24 Hour") 0.6
+                                    uitext (concatword (? (! $wallclock) "^f4") $uistr_options_15) 0.6
                                 ] 0.178 $UI_optrowh [wallclock24 (! $wallclock24)] -1
                                 UIbutton "hold2" [
                                     UIcheckbox $wallclocksecs 0.016
-                                    uitext (concatword (? (! $wallclock) "^f4") "Seconds") 0.6
+                                    uitext (concatword (? (! $wallclock) "^f4") $uistr_options_16) 0.6
                                 ] 0.178 $UI_optrowh [wallclocksecs (! $wallclocksecs)] -1
                             ]
                             uialign* -1 0
@@ -188,21 +188,21 @@ UImenu "options" [
                         uitablerow [
                             UIbutton "hold2" [
                                 UIcheckbox $hudgun 0.016
-                                uitext "Show Weapon" 0.6
+                                uitext $uistr_options_17 0.6
                             ] $UI_optc1wB $UI_optrowh [hudgun (! $hudgun)] -1
                             uialign* -1 0
                         ]
                         uitablerow [
                             UIbutton "hold2" [
                                 UIcheckbox $damagescreen 0.016
-                                uitext "Bloody Screen" 0.6
+                                uitext $uistr_options_18 0.6
                             ] $UI_optc1wB $UI_optrowh [damagescreen (! $damagescreen)] -1
                             uialign* -1 0
                         ]
                         uitablerow [
                             UIbutton "hold2" [
                                 UIcheckbox $blood 0.016
-                                uitext "Blood" 0.6
+                                uitext $uistr_options_19 0.6
                             ] $UI_optc1wB $UI_optrowh [blood (! $blood)] -1
                             uialign* -1 0
                         ]
@@ -210,84 +210,90 @@ UImenu "options" [
                         uitablerow [
                             UIbutton "hold2" [
                                 UIcheckbox $showdead 0.016
-                                uitext "Show Dead Players" 0.6
+                                uitext $uistr_options_20 0.6
                             ] $UI_optc1wB $UI_optrowh [showdead (! $showdead)] -1
                             UIhslider ragdollmillis 0 300000 5000 0.3 $UI_optrowh [uitext (concatword (? $showdead "^f4") (div $ragdollmillis 1000)) 0.6]
                             uialign* -1 0
                         ]
                         uitablerow [
-                            uihlist 0.01 [uifill $UI_optc1wA ; uitext (concatword (? $showdead "^f4") "Ragdoll Velocity") 0.6]
+                            uihlist 0.01 [uifill $UI_optc1wA ; uitext (concatword (? $showdead "^f4") $uistr_options_21) 0.6]
                             UIhslider deadpush 1 20 1 0.3 $UI_optrowh [uitext (concatword (? $showdead "^f4") $deadpush) 0.6]
                             uialign* -1 0
                         ]
                         uitablerow [
-                            uihlist 0.01 [uifill $UI_optc1wA ; uitext "Fullbright Models" 0.6]
+                            uihlist 0.01 [uifill $UI_optc1wA ; uitext $uistr_options_22 0.6]
                             uihlist 0 [
-                                UIlistslider fullbrightmodels = [0 "^f4off" 60 "^f1subtle" 100 "^f0bright" 150 "^f2overbright" 200 "^f3max"] 0.3 $UI_optrowh
+                                UIlistslider fullbrightmodels = [
+                                    0   @(concatword "^f4" $uistr_options_fbr_0)
+                                    60  @(concatword "^f1" $uistr_options_fbr_1)
+                                    100 @(concatword "^f0" $uistr_options_fbr_2)
+                                    150 @(concatword "^f2" $uistr_options_fbr_3)
+                                    200 @(concatword "^f3" $uistr_options_fbr_4)
+                                ] 0.3 $UI_optrowh
                                 uifield fullbrightmodels 3 [] 0.65 style_generic_focus
                             ]
                             uialign* -1 0
                         ]
                         UI_optbar//----------------------------------------------------------------------
                         uitablerow [
-                            uihlist 0.01 [uifill $UI_optc1wA ; uitext "Radar" 0.6]
+                            uihlist 0.01 [uifill $UI_optc1wA ; uitext $uistr_options_28 0.6]
                             uihlist 0 [
                                 UIbutton "hold2" [
                                     UIcheckbox $minimapshowteammates 0.016
-                                    uitext "Teammates" 0.6
+                                    uitext $uistr_options_29 0.6
                                 ] 0.178 $UI_optrowh [minimapshowteammates (! $minimapshowteammates)] -1
                                 UIbutton "hold2" [
                                     UIcheckbox $showminimap 0.016
-                                    uitext "Mini-Map" 0.6
+                                    uitext $uistr_options_30 0.6
                                 ] 0.178 $UI_optrowh [showminimap (! $showminimap)] -1
                             ]
                             uialign* -1 0
                         ]
                         UI_optbar//----------------------------------------------------------------------
                         uitablerow [
-                            uihlist 0.01 [uifill $UI_optc1wA ; uitext "Scoreboard" 0.6]
+                            uihlist 0.01 [uifill $UI_optc1wA ; uitext $uistr_options_31 0.6]
                             uivlist 0 [
                                 uihlist 0 [
                                     UIbutton "hold2" [
                                         UIcheckbox $showkills 0.016
-                                        uitext "Kills" 0.6
+                                        uitext $uistr_options_32 0.6
                                     ] 0.178 $UI_optrowh [showkills (! $showkills)] -1
                                     UIbutton "hold2" [
                                         UIcheckbox $showdeaths 0.016
-                                        uitext "Deaths" 0.6
+                                        uitext $uistr_options_33 0.6
                                     ] 0.178 $UI_optrowh [showdeaths (! $showdeaths)] -1
                                 ]
                                 uihlist 0 [
                                     UIbutton "hold2" [
                                         UIcheckbox $showscore 0.016
-                                        uitext "Score" 0.6
+                                        uitext $uistr_options_34 0.6
                                     ] 0.178 $UI_optrowh [showscore (! $showscore)] -1
                                     uifill 0.178
                                 ]
                                 uihlist 0 [
                                     UIbutton "hold2" [
                                         UIcheckbox $showping 0.016
-                                        uitext "Ping" 0.6
+                                        uitext $uistr_options_35 0.6
                                     ] 0.178 $UI_optrowh [showping (! $showping)] -1
                                     UIbutton "hold2" [
                                         UIcheckbox $showclientnum 0.016
-                                        uitext "Client#" 0.6
+                                        uitext $uistr_options_36 0.6
                                     ] 0.178 $UI_optrowh [showclientnum (! $showclientnum)] -1
                                 ]
                                 uihlist 0 [
                                     UIbutton "hold2" [
                                         UIcheckbox $showip 0.016
-                                        uitext "IP:Port" 0.6
+                                        uitext $uistr_options_37 0.6
                                     ] 0.178 $UI_optrowh [showip (! $showip)] -1
                                     UIbutton "hold2" [
                                         UIcheckbox $showspectators 0.016
-                                        uitext "Spectators" 0.6
+                                        uitext $uistr_options_38 0.6
                                     ] 0.178 $UI_optrowh [showspectators (! $showspectators)] -1
                                 ]
                                 uihlist 0 [
                                     UIbutton "hold2" [
                                         UIcheckbox $sbtransparent 0.016
-                                        uitext "Transparent" 0.6
+                                        uitext $uistr_options_39 0.6
                                     ] 0.178 $UI_optrowh [sbtransparent (! $sbtransparent)] -1
                                     uifill 0.178
                                 ]
@@ -299,7 +305,7 @@ UImenu "options" [
                     ] 1 [//Edit/////////////////////////////////////////////////////////////////////////
                         UI_optbar//----------------------------------------------------------------------
                         uitablerow [
-                            uihlist 0.01 [uifill $UI_optc1wA ; uitext "Shift Floatspeed" 0.6]
+                            uihlist 0.01 [uifill $UI_optc1wA ; uitext $uistr_options_40 0.6]
                             uihlist 0 [
                                 UIhslider editfloatspeed 10 10000 10 0.3 $UI_optrowh [uitext $editfloatspeed 0.6]
                                 uifield editfloatspeed 4 [] 0.65 style_generic_focus
@@ -310,69 +316,73 @@ UImenu "options" [
                     ] 2 [//Graphics/////////////////////////////////////////////////////////////////////
                         UI_optbar//----------------------------------------------------------------------
                         uitablerow [
-                            uihlist 0.01 [uifill $UI_optc1wA ; uitext "Shadow Resolution" 0.6]
-                            UIlistslider smsize = [11 "^f1low" 12 "^f0medium" 13 "^f2high"] 0.3 $UI_optrowh
+                            uihlist 0.01 [uifill $UI_optc1wA ; uitext $uistr_options_41 0.6]
                             uialign* -1 0
                         ]
                         uitablerow [
-                            uihlist 0.01 [uifill $UI_optc1wA ; uitext "Shadow Filtering" 0.6]
-                            UIlistslider smfilter = [0 "^f1low" 1 "^f0medium" 2 "^f2high" 3 "^f3ultra"] 0.3 $UI_optrowh
+                            uihlist 0.01 [uifill $UI_optc1wA ; uitext $uistr_options_42 0.6]
+                            UIlistslider smfilter = [
+                                0 @(concatword "^f1" $uistr_options_g_0)
+                                1 @(concatword "^f0" $uistr_options_g_1)
+                                2 @(concatword "^f2" $uistr_options_g_2)
+                                3 @(concatword "^f3" $uistr_options_g_3)
+                            ] 0.3 $UI_optrowh
                             uialign* -1 0
                         ]
                         uitablerow [
                             uihlist 0.01 [
                                 uifill $UI_optc1wA
-                                uitext "Global Illumination" 0.6
+                                uitext $uistr_options_43 0.6
                             ]
                             UIlistslider rhtaps = [
-                                12 @(concatword (? (! $gi) "^f4" "^f1") "low")
-                                20 @(concatword (? (! $gi) "^f4" "^f0") "medium")
-                                32 @(concatword (? (! $gi) "^f4" "^f2") "high")
+                                12 @(concatword (? (! $gi) "^f4" "^f1") $uistr_options_g_0)
+                                20 @(concatword (? (! $gi) "^f4" "^f0") $uistr_options_g_1)
+                                32 @(concatword (? (! $gi) "^f4" "^f2") $uistr_options_g_2)
                             ] 0.3 $UI_optrowh
                             uialign* -1 0
                         ]
                         uitablerow [
                             UIbutton "hold2" [
                                 UIcheckbox $ao 0.016
-                                uitext "SSAO" 0.6
+                                uitext $uistr_options_44 0.6
                             ] $UI_optc1wB $UI_optrowh [ao (! $ao)] -1
                             UIlistslider aotaps = [
-                                5  @(concatword (? (! $ao) "^f4" "^f1") "low")
-                                8  @(concatword (? (! $ao) "^f4" "^f0") "medium")
-                                12 @(concatword (? (! $ao) "^f4" "^f2") "high")
+                                5  @(concatword (? (! $ao) "^f4" "^f1") $uistr_options_g_0)
+                                8  @(concatword (? (! $ao) "^f4" "^f0") $uistr_options_g_1)
+                                12 @(concatword (? (! $ao) "^f4" "^f2") $uistr_options_g_2)
                             ] 0.3 $UI_optrowh [aobilateral (? (>= $aotaps 8) 4 3)]
                             uialign* -1 0
                         ]
                         uitablerow [
                             UIbutton "hold2" [
                                 UIcheckbox $volumetric 0.016
-                                uitext "Volumetric Lighting" 0.6
+                                uitext $uistr_options_45 0.6
                             ] $UI_optc1wB $UI_optrowh [volumetric (! $volumetric)] -1
                             UIlistslider volsteps = [
-                                12 @(concatword (? (! $volumetric) "^f4" "^f1") "low")
-                                16 @(concatword (? (! $volumetric) "^f4" "^f0") "medium")
-                                24 @(concatword (? (! $volumetric) "^f4" "^f2") "high")
+                                12 @(concatword (? (! $volumetric) "^f4" "^f1") $uistr_options_g_0)
+                                16 @(concatword (? (! $volumetric) "^f4" "^f0") $uistr_options_g_1)
+                                24 @(concatword (? (! $volumetric) "^f4" "^f2") $uistr_options_g_2)
                             ] 0.3 $UI_optrowh [
                                 volbilateral (? (>= $volsteps 16) 2 1)
                             ]
                             uialign* -1 0
                         ]
                         uitablerow [
-                            uihlist 0.01 [uifill $UI_optc1wA ; uitext "Water" 0.6]
+                            uihlist 0.01 [uifill $UI_optc1wA ; uitext $uistr_options_46 0.6]
                             uivlist 0 [
                                 uihlist 0 [
                                     UIbutton "hold2" [
                                         UIcheckbox $waterreflect 0.016
-                                        uitext "reflection" 0.6
+                                        uitext $uistr_options_wtr_0 0.6
                                     ] 0.178 $UI_optrowh [waterreflect (! $waterreflect)] -1
                                     UIbutton "hold2" [
                                         UIcheckbox $caustics 0.016
-                                        uitext "caustics" 0.6
+                                        uitext $uistr_options_wtr_1 0.6
                                     ] 0.178 $UI_optrowh [caustics (! $caustics)] -1
                                 ]
                                 UIbutton "hold2" [
                                     UIcheckbox $vertwater 0.016
-                                    uitext "animation" 0.6
+                                    uitext $uistr_options_wtr_2 0.6
                                 ] 0.178 $UI_optrowh [vertwater (! $vertwater)] -1
                                 uialign* -1 -1
                             ]
@@ -381,21 +391,21 @@ UImenu "options" [
                         uitablerow [
                             UIbutton "hold2" [
                                 UIcheckbox $softparticles 0.016
-                                uitext "Soft Particles" 0.6
+                                uitext $uistr_options_47 0.6
                             ] $UI_optc1wB $UI_optrowh [softparticles (! $softparticles)] -1
                             uialign* -1 0
                         ]
                         uitablerow [
                             UIbutton "hold2" [
                                 UIcheckbox $stains 0.016
-                                uitext "Stains" 0.6
+                                uitext $uistr_options_48 0.6
                             ] $UI_optc1wB $UI_optrowh [stains (! $stains)] -1
                             uihlist 0 [
                                 UIlistslider stainfade = [
-                                    2 @(concatword (? (! $stains) "^f4" "^f1") "instant-fade")
-                                    15 @(concatword (? (! $stains) "^f4" "^f0") "quick-fade")
-                                    30 @(concatword (? (! $stains) "^f4" "^f2") "moderate-fade")
-                                    60 @(concatword (? (! $stains) "^f4" "^f3") "slow-fade")
+                                    2  @(concatword (? (! $stains) "^f4" "^f1") $uistr_options_stn_0)
+                                    15 @(concatword (? (! $stains) "^f4" "^f0") $uistr_options_stn_1)
+                                    30 @(concatword (? (! $stains) "^f4" "^f2") $uistr_options_stn_2)
+                                    60 @(concatword (? (! $stains) "^f4" "^f3") $uistr_options_stn_3)
                                 ] 0.3 $UI_optrowh [
                                     maxstaintris (? (> $stainfade 15) 8192 2048)
                                 ]
@@ -408,14 +418,14 @@ UImenu "options" [
                         uitablerow [
                             UIbutton "hold2" [
                                 UIcheckbox $grass 0.016
-                                uitext "3D Grass" 0.6
+                                uitext $uistr_options_49 0.6
                             ] $UI_optc1wB $UI_optrowh [grass (! $grass)] -1
                             uihlist 0 [
                                 UIlistslider grassdist = [
-                                    128 @(concatword (? (! $grass) "^f4" "^f1") "quick-fade")
-                                    256 @(concatword (? (! $grass) "^f4" "^f0") "moderate-fade")
-                                    512 @(concatword (? (! $grass) "^f4" "^f2") "slow-fade")
-                                    1024 @(concatword (? (! $grass) "^f4" "^f3") "slower-fade")
+                                    128  @(concatword (? (! $grass) "^f4" "^f1") $uistr_options_gra_0)
+                                    256  @(concatword (? (! $grass) "^f4" "^f0") $uistr_options_gra_1)
+                                    512  @(concatword (? (! $grass) "^f4" "^f2") $uistr_options_gra_2)
+                                    1024 @(concatword (? (! $grass) "^f4" "^f3") $uistr_options_gra_3)
                                 ] 0.3 $UI_optrowh
                                 uifield grassdist 4 [] 0.65 style_generic_focus
                             ]
@@ -427,58 +437,58 @@ UImenu "options" [
                         uitablerow [
                             UIbutton "hold2" [
                                 UIcheckbox $fullscreen 0.016
-                                uitext "Fullscreen" 0.6
+                                uitext $uistr_options_50 0.6
                             ] $UI_optc1wB $UI_optrowh [fullscreen (! $fullscreen)] -1
                             uialign* -1 0
                         ]
                         UI_optbar//----------------------------------------------------------------------
                         uitablerow [
-                            uihlist 0.01 [uifill $UI_optc1wA ; uitext "Anisotropic Filtering" 0.6]
-                            UIlistslider aniso = [0 "^f4off" 2 "^f12x" 4 "^f04x" 8 "^f28x" 16 "^f316x"] 0.3 $UI_optrowh
+                            uihlist 0.01 [uifill $UI_optc1wA ; uitext $uistr_options_51 0.6]
+                            UIlistslider aniso = [0 @(concatword "^f4" $uistr_options_off) 2 "^f12x" 4 "^f04x" 8 "^f28x" 16 "^f316x"] 0.3 $UI_optrowh
                             uialign* -1 0
                         ]
                         UI_optbar//----------------------------------------------------------------------
                         uitablerow [
                             UIbutton "hold2" [
                                 UIcheckbox $smaa 0.016
-                                uitext "Morphological AA" 0.6
+                                uitext $uistr_options_52 0.6
                             ] $UI_optc1wB $UI_optrowh [smaa (! $smaa)] -1
                             UIlistslider smaaquality = [
-                                0 @(concatword (? (! $smaa) "^f4" "^f1") "low")
-                                1 @(concatword (? (! $smaa) "^f4" "^f0") "medium")
-                                2 @(concatword (? (! $smaa) "^f4" "^f2") "high")
-                                3 @(concatword (? (! $smaa) "^f4" "^f3") "ultra")
+                                0 @(concatword (? (! $smaa) "^f4" "^f1") $uistr_options_g_0)
+                                1 @(concatword (? (! $smaa) "^f4" "^f0") $uistr_options_g_1)
+                                2 @(concatword (? (! $smaa) "^f4" "^f2") $uistr_options_g_2)
+                                3 @(concatword (? (! $smaa) "^f4" "^f3") $uistr_options_g_3)
                             ] 0.3 $UI_optrowh [smaacoloredge (>= $smaaquality 3)]
                             uialign* -1 0
                         ]
                         uitablerow [
                             UIbutton "hold2" [
                                 UIcheckbox $tqaa 0.016
-                                uitext "Temporal AA" 0.6
+                                uitext $uistr_options_53 0.6
                             ] $UI_optc1wB $UI_optrowh [tqaa (! $tqaa)] -1
                             uialign* -1 0
                         ]
                         uitablerow [
                             UIbutton "hold2" [
                                 UIcheckbox $fxaa 0.016
-                                uitext "FXAA" 0.6
+                                uitext $uistr_options_54 0.6
                             ] $UI_optc1wB $UI_optrowh [fxaa (! $fxaa)] -1
                             UIlistslider fxaaquality = [
-                                0 @(concatword (? (! $fxaa) "^f4" "^f1") "low")
-                                1 @(concatword (? (! $fxaa) "^f4" "^f0") "medium")
-                                2 @(concatword (? (! $fxaa) "^f4" "^f2") "high")
-                                3 @(concatword (? (! $fxaa) "^f4" "^f3") "ultra")
+                                0 @(concatword (? (! $fxaa) "^f4" "^f1") $uistr_options_g_0)
+                                1 @(concatword (? (! $fxaa) "^f4" "^f0") $uistr_options_g_1)
+                                2 @(concatword (? (! $fxaa) "^f4" "^f2") $uistr_options_g_2)
+                                3 @(concatword (? (! $fxaa) "^f4" "^f3") $uistr_options_g_3)
                             ] 0.3 $UI_optrowh
                             uialign* -1 0
                         ]
                         uitablerow [
-                            uihlist 0.01 [uifill $UI_optc1wA ; uitext "Multisample AA" 0.6]
-                            UIlistslider msaa = [0 "^f4off" 2 "^f12x" 4 "^f04x" 8 "^f28x" 16 "^f316x"] 0.3 $UI_optrowh
+                            uihlist 0.01 [uifill $UI_optc1wA ; uitext $uistr_options_55 0.6]
+                            UIlistslider msaa = [0 @(concatword "^f4" $uistr_options_off) 2 "^f12x" 4 "^f04x" 8 "^f28x" 16 "^f316x"] 0.3 $UI_optrowh
                             uialign* -1 0
                         ]
                         UI_optbar//----------------------------------------------------------------------
                         uitablerow [
-                            uihlist 0.01 [uifill $UI_optc1wA ; uitext "Gamma" 0.6]
+                            uihlist 0.01 [uifill $UI_optc1wA ; uitext $uistr_options_56 0.6]
                             uihlist 0 [
                                 UIhslider gamma 30 300 5 0.3 $UI_optrowh [uitext $gamma 0.6]
                                 uifield gamma 3 [] 0.65 style_generic_focus
@@ -488,11 +498,11 @@ UImenu "options" [
                         uitablerow [
                             UIbutton "hold2" [
                                 UIcheckbox $vsync 0.016
-                                uitext "V-sync" 0.6
+                                uitext $uistr_options_57 0.6
                             ] $UI_optc1wB $UI_optrowh [vsync (! $vsync)] -1
                             UIbutton "hold2" [
                                 UIcheckbox $vsynctear 0.016
-                                uitext (concatword (? (! $vsync) "^f4") "Tear")  0.6
+                                uitext (concatword (? (! $vsync) "^f4") $uistr_options_58)  0.6
                             ] 0.15 $UI_optrowh [vsynctear (! $vsynctear)] -1
                             uialign* -1 0
                         ]
@@ -500,9 +510,9 @@ UImenu "options" [
                     ] 4 [//Resolution///////////////////////////////////////////////////////////////////
                         UI_optbar//----------------------------------------------------------------------
                         uitablerow [
-                            uihlist 0.01 [uifill $UI_optc1wA ; uitext "Aspect Ratio" 0.6]
+                            uihlist 0.01 [uifill $UI_optc1wA ; uitext $uistr_options_59 0.6]
                             UIlistslider UI_aspectratio =s $opt_ratios_assoc 0.3 $UI_optrowh [
-                                if (=s $UI_aspectratio "custom") [] [
+                                if (=s $UI_aspectratio $uistr_options_asp_0) [] [
                                     UI_resolution = (at $[UI_ratio@UI_aspectratio] 1)
                                     screenw (at $UI_resolution 0)
                                     screenh (at $UI_resolution 1)
@@ -512,27 +522,27 @@ UImenu "options" [
                         ]
                         uitablerow [
                             UIbutton "hold2" [
-                                UIcheckbox (!=s $UI_aspectratio "custom") 0.016
-                                uitext "Preset Resolution" 0.6
+                                UIcheckbox (!=s $UI_aspectratio $uistr_options_asp_0) 0.016
+                                uitext $uistr_options_60 0.6
                             ] $UI_optc1wB $UI_optrowh [
-                                if (=s $UI_aspectratio "custom") [
+                                if (=s $UI_aspectratio $uistr_options_asp_0) [
                                     UI_findratio
-                                    if (=s $UI_aspectratio "custom") [
+                                    if (=s $UI_aspectratio $uistr_options_asp_0) [
                                         UI_aspectratio = "16:10"
                                         UI_resolution = (at $[UI_ratio@UI_aspectratio] 1)
                                         screenw (at $UI_resolution 0)
                                         screenh (at $UI_resolution 1)
                                     ]
                                 ] [
-                                    UI_aspectratio = "custom"
+                                    UI_aspectratio = $uistr_options_asp_0
                                 ]
                             ] -1
-                            if (=s $UI_aspectratio "custom") [
+                            if (=s $UI_aspectratio $uistr_options_asp_0) [
                                 uihlist 0.009 [
                                     uifield screenw 5 [] 0.65 style_generic_focus
                                     uitext "x" 0.6
                                     uifield screenh 5 [] 0.65 style_generic_focus
-                                    UIbutton "" [uitext "Native" 0.6] 0.1 $UI_optrowh [
+                                    UIbutton "" [uitext $uistr_options_61 0.6] 0.1 $UI_optrowh [
                                         UI_resolution = (concat $desktopw $desktoph)
                                         UI_findratio
                                         screenw (at $UI_resolution 0)
@@ -553,8 +563,8 @@ UImenu "options" [
                         ]
                         UI_optbar//----------------------------------------------------------------------
                         uitablerow [
-                            uihlist 0.01 [uifill $UI_optc1wA ; uitext "Upscaling" 0.6]
-                            UIlistslider gscalecubic = [0 "^f1low" 1 "^f0high"] 0.3 $UI_optrowh
+                            uihlist 0.01 [uifill $UI_optc1wA ; uitext $uistr_options_62 0.6]
+                            UIlistslider gscalecubic = [0 @(concatword "^f1" $uistr_options_g_0) 1 @(concatword "^f0" $uistr_options_g_2)] 0.3 $UI_optrowh
                             uialign* -1 0
                         ]
                         UI_optbar//----------------------------------------------------------------------
@@ -563,13 +573,13 @@ UImenu "options" [
                         uitablerow [
                             UIbutton "hold2" [
                                 UIcheckbox $sound 0.016
-                                uitext "Enable Audio" 0.6
+                                uitext $uistr_options_63 0.6
                             ] $UI_optc1wB $UI_optrowh [sound (! $sound)] -1
                             uialign* -1 0
                         ]
                         UI_optbar//----------------------------------------------------------------------
                         uitablerow [
-                            uihlist 0.01 [uifill $UI_optc1wA ; uitext (concatword (? (! $sound) "^f4") "Sound Volume") 0.6]
+                            uihlist 0.01 [uifill $UI_optc1wA ; uitext (concatword (? (! $sound) "^f4") $uistr_options_64) 0.6]
                             uihlist 0 [
                                 UIhslider soundvol 0 255 5 0.3 $UI_optrowh [uitext $soundvol 0.6]
                                 uifield soundvol 3 [] 0.65 style_generic_focus
@@ -577,7 +587,7 @@ UImenu "options" [
                             uialign* -1 0
                         ]
                         uitablerow [
-                            uihlist 0.01 [uifill $UI_optc1wA ; uitext (concatword (? (! $sound) "^f4") "Music Volume") 0.6]
+                            uihlist 0.01 [uifill $UI_optc1wA ; uitext (concatword (? (! $sound) "^f4") $uistr_options_65) 0.6]
                             uihlist 0 [
                                 UIhslider musicvol 0 255 5 0.3 $UI_optrowh [uitext $musicvol 0.6]
                                 uifield musicvol 3 [] 0.65 style_generic_focus
@@ -588,7 +598,7 @@ UImenu "options" [
                         uitablerow [
                             UIbutton "hold2" [
                                 UIcheckbox $hitsound 0.016
-                                uitext (concatword (? (! $sound) "^f4") "Hit Confirmation") 0.6
+                                uitext (concatword (? (! $sound) "^f4") $uistr_options_66) 0.6
                             ] $UI_optc1wB $UI_optrowh [hitsound (! $hitsound)] -1
                             uialign* -1 0
                         ]
@@ -600,7 +610,7 @@ UImenu "options" [
         UIvscroll 0.02 0.6 1.421 0.5
     ]
 ] [
-    UI_aspectratio = "custom"
+    UI_aspectratio = $uistr_options_asp_0
     UI_resolution  = (concat $screenw $screenh)
     UI_findratio
 ] [if (pendingchanges) [showui "changes"]] [] "Options"


### PR DESCRIPTION
These commits change strings to aliases in `options.cfg` to pave the way for translating Imprimis.

b278ca3402b3bacd5047f33661d31744c2580266 is temporary. It should eventually be replaced by a mechanism which reads a config file and determines which language the user prefers.

Possible changes to be considered:

* Instead of `uistr_options_n`, make variable names a little more descriptive like `uistr_o_graphics_n` or something of the sort.