### PR TITLE
Fix weapon fire animation playing while overheating

### DIFF
--- a/game/weapon.cpp
+++ b/game/weapon.cpp
@@ -243,7 +243,7 @@ namespace game
             if(name[0])
             {
                 int gun = getweapon(name);
-                if(validgun(gun) && gun != player1->gunselect && player1->ammo[gun])
+                if(validgun(gun) && gun != player1->gunselect && player1->ammo[gun] && weaponallowed(gun))
                 {
                     gunselect(gun, player1);
                     return;
@@ -251,11 +251,11 @@ namespace game
             }
             else
             {
-                weaponswitch(player1);
                 return;
             }
         }
     });
+
 
     void offsetray(const vec &from, const vec &to, int spread, float range, vec &dest)
     {

--- a/game/weapon.cpp
+++ b/game/weapon.cpp
@@ -1001,12 +1001,12 @@ namespace game
         int gun = d->gunselect,
             act = d->attacking,
             atk = guns[gun].attacks[act];
-        d->lastaction = lastmillis;
-        d->lastattack = atk;
         if(d->heat[gun] > attacks[atk].maxheat) // check if weapon has overheated
         {
             return;
         }
+        d->lastaction = lastmillis;
+        d->lastattack = atk;
         if(!d->ammo[gun])
         {
             if(d==player1)


### PR DESCRIPTION
Fix weapon fire animation playing while overheating. Fix for issue #35 
Also fix weapon switching to disallowed weapons with the `weapon` command.