### PR TITLE
Correct git repository link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ has been compiled (as it cannot find the needed shared library).
 
 Once libprimis is installed, Imprimis can be successfully installed. The project
 can be downloaded by running the following command at the desired install location:
-`git clone https://github.com/project-imprimis/libprimis.git --recurse-submodules`
+`git clone https://github.com/project-imprimis/imprimis.git --recurse-submodules`
 
 Once the game has been downloaded, access the game directory with `cd imprimis`.
 The game can now be compiled with `make` (or `make -jN` for N threaded compilation).


### PR DESCRIPTION
The guide to install Imprimis on Linux incorrectly tells the user to clone the **lib**primis repository after having installed a copy of `libprimis.so`.

Please only create pull requests that close an open issue; if you would like to
make a change to the game, please create an issue first that can be verified before
creating a pull request. Unsolicited pull requests without a corresponding issue
may be closed and ignored with no further feedback given.

Thanks for contributing to Imprimis!

=== LEGAL NOTICE ===

By creating a pull request, and in lieu of explicit licensing terms provided,
you agree to release the work contained therein under license terms compatible
with the Imprimis project; that is, under CC-BY-SA (for assets) or the zlib
license (for code). This license grant is provided regardless of the merge of
content or code with the engine and is irrevocable (like all other open source
licenses require).

If you do not want to contribute your code as being part of the generic Imprimis
project copyright, or would like to opt out of providing copyright immediately
upon the creation of the pull request, please make sure that your pull request
specifically addresses this. Note that the project cannot accept content
licenced under GPL licenses or other, more strict licensing terms; all content
is to be licenced permissively.
