### PR TITLE
Add Windows build CI

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -43,3 +43,15 @@ jobs:
       # Add additional options to the MSBuild command line here (like platform or verbosity level).
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
       run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+      
+    - name: Upload libprimis.lib artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: imprimis-windows
+        path: |
+          ./imprimis.bat
+          ./README.md
+          ./bin64/
+          ./config/
+          ./doc/
+          ./media/

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -1,0 +1,33 @@
+name: MSBuild
+
+on: [push]
+
+env:
+  # Path to the solution file relative to the root of the project.
+  SOLUTION_FILE_PATH: ./vcpp/imprimis.sln
+
+  # Configuration type to build.
+  # You can convert this to a build matrix if you need coverage of multiple configuration types.
+  # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+  BUILD_CONFIGURATION: Release
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+
+#     afaik this isnt necessary
+#    - name: Restore NuGet packages
+#      working-directory: ${{env.GITHUB_WORKSPACE}}
+#      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Build
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      # Add additional options to the MSBuild command line here (like platform or verbosity level).
+      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -21,6 +21,15 @@ jobs:
       with:
         submodules: true
 
+    - name: Download libprimis.lib artifact
+      uses: dawidd6/action-download-artifact@v2.14.1
+        workflow: msbuild.yml
+        branch: master
+        name: libprimis-windows
+        path: ./
+        repo: TheEgghead27/libprimis
+        branch: build-ci
+
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.0.2
 

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -44,7 +44,7 @@ jobs:
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
       run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
       
-    - name: Upload libprimis.lib artifact
+    - name: Upload Imprimis Windows binary artifact
       uses: actions/upload-artifact@v2
       with:
         name: imprimis-windows

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -16,7 +16,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Clone repository and submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: true
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.0.2

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -23,8 +23,8 @@ jobs:
 
     - name: Download libprimis.lib artifact
       uses: dawidd6/action-download-artifact@v2.14.1
+      with:
         workflow: msbuild.yml
-        branch: master
         name: libprimis-windows
         path: ./
         repo: TheEgghead27/libprimis


### PR DESCRIPTION
This uses Github CI to build binaries of Imprimis for Windows, then uploads the binaries and dependency files as an artifact. It depends on having libprimis CI being set up to have libprimis.lib artifacts available.
The `repo` and `branch` arguments of the `Download libprimis.lib artifact` job should be altered to point towards the project-imprimis libprimis repository and the appropriate branch.
Closes #47.

Please only create pull requests that close an open issue; if you would like to
make a change to the game, please create an issue first that can be verified before
creating a pull request. Unsolicited pull requests without a corresponding issue
may be closed and ignored with no further feedback given.

Thanks for contributing to Imprimis!

=== LEGAL NOTICE ===

By creating a pull request, and in lieu of explicit licensing terms provided,
you agree to release the work contained therein under license terms compatible
with the Imprimis project; that is, under CC-BY-SA (for assets) or the zlib
license (for code). This license grant is provided regardless of the merge of
content or code with the engine and is irrevocable (like all other open source
licenses require).

If you do not want to contribute your code as being part of the generic Imprimis
project copyright, or would like to opt out of providing copyright immediately
upon the creation of the pull request, please make sure that your pull request
specifically addresses this. Note that the project cannot accept content
licenced under GPL licenses or other, more strict licensing terms; all content
is to be licenced permissively.
