### PR TITLE
configurable master server address

### DIFF
--- a/config/servers.cfg
+++ b/config/servers.cfg
@@ -1,3 +1,6 @@
 // servers connected to are added here automatically
 
 addserver localhost 42069
+
+// change master server. currently untested
+// mastername "project-imprimis.org"


### PR DESCRIPTION
This pull request modifies the `server::defaultmaster()` function to take a string parameter to change the hardcoded value.
Moreover it adds a cubescript function `setmastername` to change the `mastername` variable