### PR TITLE
Add installation instructions & correct lib path

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,37 @@ game assets (all located in submodules).
 The Imprimis game requires a separate server in order to play locally. For the
 game server, see https://github.com/project-imprimis/imprimis-gameserver.
 
-## Linux Installation Instructions
+## Installation Instructions
+
+Download the game from https://github.com/project-imprimis/imprimis/releases.
+Choose `imprimis-windows.zip` or `imprimis-linux.zip` depending on your OS.
+
+On Linux, extract the zip file and follow these instructions.
+
+1. Go into the extracted folder.
+```bash
+cd imprimis-linux
+```
+2. Copy the `libprimis.so` library to the `/usr/lib` folder.
+```bash
+sudo cp libprimis.so /usr/lib
+```
+3. Make the game client and the runner script executable.
+```bash
+chmod +x native_client imprimis_unix
+```
+4. Run Imprimis using the runner script.
+```bash
+./imprimis_unix
+```
+
+## Developers
 
 Imprimis requires the `libprimis` shared library, which can be created by building
 the libprimis engine located at https://github.com/project-imprimis/libprimis.
 
 Imprimis requires the library built by libprimis (`libprimis.so`) to be located in
-one of the standard Linux library directories (typically `/usr/local/lib`). If the
+one of the standard Linux library directories (typically `/usr/lib`). If the
 `libprimis.so` file has not been places there, Imprimis will fail to run once it
 has been compiled (as it cannot find the needed shared library).
 


### PR DESCRIPTION
Change `/usr/local/lib` to `/usr/lib` because Imprimis will not run unless `libprimis.so` is located in `/usr/lib`. Also, add numbered instructions that make it easier to run the pre-compiled Imprimis client.