### PR TITLE
Remove VARN, DIR, and some ICOMMAND macros.

### DIFF
--- a/game/gameclient.cpp
+++ b/game/gameclient.cpp
@@ -817,7 +817,6 @@ namespace game
             case Edit_Copy:
             case Edit_Paste:
             case Edit_DelCube:
-            case Edit_AddCube:
             {
                 switch(op)
                 {
@@ -843,6 +842,7 @@ namespace game
                    sel.corner);               //13
                 break;
             }
+            case Edit_AddCube:
             case Edit_Rotate:
             {
                 addmsg(NetMsg_EditFace + op, "ri9i5",


### PR DESCRIPTION
This commit:
- Replaces the last VARN macro in Imprimis (there are no more in Libprimis).
- Replaces ICOMMAND macros in game.cpp with the `addicommand` function.
- Replaces the DIR macro with the `movement` function.
- Creates the `Direction` enum for using within the `move_forward` and other similar functions.
- Refactors the `gameent->sprinting` attribute from being an integer into being a bool.
