### PR TITLE
Adapt Makefile for packaging and add FreeDesktop application metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,21 +55,20 @@ emplace: uninstall  # clean out installation locations to prevent pollution
 	mkdir --parents $(DESTDIR)$(PREFIX)/share/applications/
 	mkdir --parents $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps/
 	mkdir --parents $(DESTDIR)$(PREFIX)/share/metainfo/
-	mkdir --parents $(DESTDIR)$(PREFIX)/share/pixmaps/
 	cp -R ./ $(DESTDIR)$(PREFIX)/lib/imprimis
 	# edit install dir, not source
 	cd $(DESTDIR)$(PREFIX)/lib/imprimis; \
 		rm -rf game/ vcpp/ bin64/ enet/ libprimis-headers/ .git/ .semaphore/ imprimis.bat .gitmodules Makefile; \
  		sed -i "s|=\.$$|=$(DESTDIR)$(PREFIX)/lib/imprimis|" imprimis_unix; \
 		mv ./imprimis_unix $(DESTDIR)$(PREFIX)/bin/imprimis; \
-		cp ./media/interface/icon.png $(DESTDIR)$(PREFIX)/share/pixmaps/imprimis.png; \
 		mv ./media/interface/icon.svg $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps/org.imprimis.Imprimis.svg; \
 		mv ./org.imprimis.Imprimis.desktop $(DESTDIR)$(PREFIX)/share/applications/org.imprimis.Imprimis.desktop; \
 		mv ./org.imprimis.Imprimis.metainfo.xml $(DESTDIR)$(PREFIX)/share/metainfo/org.imprimis.Imprimis.metainfo.xml;
 
 uninstall:
-	rm -rf $(DESTDIR)$(PREFIX)/lib/imprimis/ $(DESTDIR)$(PREFIX)/share/pixmaps/imprimis.png \
+	rm -rf $(DESTDIR)$(PREFIX)/lib/imprimis/ \
+	       $(DESTDIR)$(PREFIX)/bin/imprimis \
 	       $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps/org.imprimis.Imprimis.svg \
 	       $(DESTDIR)$(PREFIX)/share/applications/org.imprimis.Imprimis.desktop \
-	       $(DESTDIR)$(PREFIX)/share/metainfo/org.imprimis.Imprimis.metainfo.xml \
-	       $(DESTDIR)$(PREFIX)/bin/imprimis
+	       $(DESTDIR)$(PREFIX)/share/metainfo/org.imprimis.Imprimis.metainfo.xml
+

--- a/Makefile
+++ b/Makefile
@@ -50,19 +50,18 @@ libenet: enet/libenet.a
 
 emplace: uninstall  # clean out installation locations to prevent pollution
 	# initialize installation directories (for minimal packager filesystems)
-	mkdir --parents $(DESTDIR)$(PREFIX)/share/
 	mkdir --parents $(DESTDIR)$(PREFIX)/share/pixmaps/
+	mkdir --parents $(DESTDIR)$(PREFIX)/lib/
 	mkdir --parents $(DESTDIR)$(PREFIX)/bin/
-	cp -R ./ $(DESTDIR)$(PREFIX)/share/imprimis
+	cp -R ./ $(DESTDIR)$(PREFIX)/lib/imprimis
 	# edit install dir, not source
-	cd $(DESTDIR)$(PREFIX)/share/imprimis; \
+	cd $(DESTDIR)$(PREFIX)/lib/imprimis; \
 		rm -rf game/ vcpp/ bin64/ enet/ libprimis-headers/ .git/ .semaphore/ imprimis.bat .gitmodules Makefile; \
-		# set launcher script to launch from installed binaries
-		sed -i "s|=\.$$|=$(DESTDIR)$(PREFIX)/share/imprimis|" imprimis_unix; \
+ 		sed -i "s|=\.$$|=$(DESTDIR)$(PREFIX)/lib/imprimis|" imprimis_unix; \
 		mv ./imprimis_unix $(DESTDIR)$(PREFIX)/bin/imprimis; \
 		cp ./media/interface/icon.png $(DESTDIR)$(PREFIX)/share/pixmaps/imprimis.png
 
 uninstall:
-	rm -rf $(DESTDIR)$(PREFIX)/share/imprimis
+	rm -rf $(DESTDIR)$(PREFIX)/lib/imprimis/
 	rm -rf $(DESTDIR)$(PREFIX)/share/pixmaps/imprimis.png
 	rm -rf $(DESTDIR)$(PREFIX)/bin/imprimis

--- a/Makefile
+++ b/Makefile
@@ -48,14 +48,21 @@ enet/libenet.a:
 	$(MAKE) -C enet
 libenet: enet/libenet.a
 
-emplace:
-	# clean out target install dir to prevent pollution
-	rm -rf $(DESTDIR)$(PREFIX)/share/imprimis
+emplace: uninstall  # clean out installation locations to prevent pollution
+	# initialize installation directories (for minimal packager filesystems)
+	mkdir --parents $(DESTDIR)$(PREFIX)/share/
+	mkdir --parents $(DESTDIR)$(PREFIX)/share/pixmaps/
+	mkdir --parents $(DESTDIR)$(PREFIX)/bin/
 	cp -R ./ $(DESTDIR)$(PREFIX)/share/imprimis
 	# edit install dir, not source
 	cd $(DESTDIR)$(PREFIX)/share/imprimis; \
-		rm -r game/ vcpp/ bin64/ enet/ libprimis-headers/ .git/ .semaphore/ imprimis.bat .gitmodules Makefile; \
+		rm -rf game/ vcpp/ bin64/ enet/ libprimis-headers/ .git/ .semaphore/ imprimis.bat .gitmodules Makefile; \
 		# set launcher script to launch from installed binaries
 		sed -i "s|=\.$$|=$(DESTDIR)$(PREFIX)/share/imprimis|" imprimis_unix; \
-		cp ./imprimis_unix $(DESTDIR)$(PREFIX)/bin/imprimis;
+		mv ./imprimis_unix $(DESTDIR)$(PREFIX)/bin/imprimis; \
+		cp ./media/interface/icon.png $(DESTDIR)$(PREFIX)/share/pixmaps/imprimis.png
 
+uninstall:
+	rm -rf $(DESTDIR)$(PREFIX)/share/imprimis
+	rm -rf $(DESTDIR)$(PREFIX)/share/pixmaps/imprimis.png
+	rm -rf $(DESTDIR)$(PREFIX)/bin/imprimis

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-CXXFLAGS= -O3 -ffast-math -std=c++17 -march=x86-64 -Wall -fsigned-char
+CXXFLAGS ?= -O3 -ffast-math -Wall
+CXXFLAGS += -std=c++17 -march=x86-64 -fsigned-char
+
+PREFIX ?= /usr/local
 
 #set appropriate library includes
 CLIENT_INCLUDES= -Igame -Ienet/include -I/usr/X11R6/include `sdl2-config --cflags`
@@ -26,6 +29,8 @@ CLIENT_OBJS= \
 
 default: client
 
+install: client emplace
+
 #cleanup build files and executable
 clean:
 	-$(RM) -r $(CLIENT_OBJS) tess_client
@@ -42,3 +47,15 @@ client:	libenet $(CLIENT_OBJS)
 enet/libenet.a:
 	$(MAKE) -C enet
 libenet: enet/libenet.a
+
+emplace:
+	# clean out target install dir to prevent pollution
+	rm -rf $(DESTDIR)$(PREFIX)/share/imprimis
+	cp -R ./ $(DESTDIR)$(PREFIX)/share/imprimis
+	# edit install dir, not source
+	cd $(DESTDIR)$(PREFIX)/share/imprimis; \
+		rm -r game/ vcpp/ bin64/ enet/ libprimis-headers/ .git/ .semaphore/ imprimis.bat .gitmodules Makefile; \
+		# set launcher script to launch from installed binaries
+		sed -i "s|=\.$$|=$(DESTDIR)$(PREFIX)/share/imprimis|" imprimis_unix; \
+		cp ./imprimis_unix $(DESTDIR)$(PREFIX)/bin/imprimis;
+

--- a/Makefile
+++ b/Makefile
@@ -50,18 +50,26 @@ libenet: enet/libenet.a
 
 emplace: uninstall  # clean out installation locations to prevent pollution
 	# initialize installation directories (for minimal packager filesystems)
-	mkdir --parents $(DESTDIR)$(PREFIX)/share/pixmaps/
-	mkdir --parents $(DESTDIR)$(PREFIX)/lib/
 	mkdir --parents $(DESTDIR)$(PREFIX)/bin/
+	mkdir --parents $(DESTDIR)$(PREFIX)/lib/
+	mkdir --parents $(DESTDIR)$(PREFIX)/share/applications/
+	mkdir --parents $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps/
+	mkdir --parents $(DESTDIR)$(PREFIX)/share/metainfo/
+	mkdir --parents $(DESTDIR)$(PREFIX)/share/pixmaps/
 	cp -R ./ $(DESTDIR)$(PREFIX)/lib/imprimis
 	# edit install dir, not source
 	cd $(DESTDIR)$(PREFIX)/lib/imprimis; \
 		rm -rf game/ vcpp/ bin64/ enet/ libprimis-headers/ .git/ .semaphore/ imprimis.bat .gitmodules Makefile; \
  		sed -i "s|=\.$$|=$(DESTDIR)$(PREFIX)/lib/imprimis|" imprimis_unix; \
 		mv ./imprimis_unix $(DESTDIR)$(PREFIX)/bin/imprimis; \
-		cp ./media/interface/icon.png $(DESTDIR)$(PREFIX)/share/pixmaps/imprimis.png
+		cp ./media/interface/icon.png $(DESTDIR)$(PREFIX)/share/pixmaps/imprimis.png; \
+		mv ./media/interface/icon.svg $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps/org.imprimis.Imprimis.svg; \
+		mv ./org.imprimis.Imprimis.desktop $(DESTDIR)$(PREFIX)/share/applications/org.imprimis.Imprimis.desktop; \
+		mv ./org.imprimis.Imprimis.metainfo.xml $(DESTDIR)$(PREFIX)/share/metainfo/org.imprimis.Imprimis.metainfo.xml;
 
 uninstall:
-	rm -rf $(DESTDIR)$(PREFIX)/lib/imprimis/
-	rm -rf $(DESTDIR)$(PREFIX)/share/pixmaps/imprimis.png
-	rm -rf $(DESTDIR)$(PREFIX)/bin/imprimis
+	rm -rf $(DESTDIR)$(PREFIX)/lib/imprimis/ $(DESTDIR)$(PREFIX)/share/pixmaps/imprimis.png \
+	       $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps/org.imprimis.Imprimis.svg \
+	       $(DESTDIR)$(PREFIX)/share/applications/org.imprimis.Imprimis.desktop \
+	       $(DESTDIR)$(PREFIX)/share/metainfo/org.imprimis.Imprimis.metainfo.xml \
+	       $(DESTDIR)$(PREFIX)/bin/imprimis

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 CXXFLAGS ?= -O3 -ffast-math -Wall
 CXXFLAGS += -std=c++17 -march=x86-64 -fsigned-char
 
+# install prefix, configurable by the user
 PREFIX ?= /usr/local
+# the DESTDIR variable is also used as an install prefix, but is meant to only be used by package builders for system images
 
 #set appropriate library includes
 CLIENT_INCLUDES= -Igame -Ienet/include -I/usr/X11R6/include `sdl2-config --cflags`
@@ -59,7 +61,7 @@ emplace: uninstall  # clean out installation locations to prevent pollution
 	# edit install dir, not source
 	cd $(DESTDIR)$(PREFIX)/lib/imprimis; \
 		rm -rf game/ vcpp/ bin64/ enet/ libprimis-headers/ .git/ .semaphore/ imprimis.bat .gitmodules Makefile; \
- 		sed -i "s|=\.$$|=$(DESTDIR)$(PREFIX)/lib/imprimis|" imprimis_unix; \
+ 		sed -i "s|=\.$$|=$(PREFIX)/lib/imprimis|" imprimis_unix; \
 		mv ./imprimis_unix $(DESTDIR)$(PREFIX)/bin/imprimis; \
 		mv ./media/interface/icon.svg $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps/org.imprimis.Imprimis.svg; \
 		mv ./org.imprimis.Imprimis.desktop $(DESTDIR)$(PREFIX)/share/applications/org.imprimis.Imprimis.desktop; \

--- a/org.imprimis.Imprimis.desktop
+++ b/org.imprimis.Imprimis.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=Imprimis
+Exec=imprimis
+Type=Application
+Icon=org.imprimis.Imprimis
+Categories=Game;Shooter;
+Terminal=false

--- a/org.imprimis.Imprimis.desktop
+++ b/org.imprimis.Imprimis.desktop
@@ -3,5 +3,6 @@ Name=Imprimis
 Exec=imprimis
 Type=Application
 Icon=org.imprimis.Imprimis
+Comment=3D FPS destroyable world shooter
 Categories=Game;Shooter;
 Terminal=false

--- a/org.imprimis.Imprimis.metainfo.xml
+++ b/org.imprimis.Imprimis.metainfo.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2022 Project Imprimis -->
 <component type="desktop-application">
     <id>org.imprimis.Imprimis</id>
     <metadata_license>CC0-1.0</metadata_license>
@@ -29,41 +30,41 @@
             on Sundays weekly, for a chance to play with other players and developers.
         </p>
     </description>
-    <icon type="local" width="512" height="512">/usr/share/pixmaps/imprimis.png</icon>
+
     <categories>
         <category>Game</category>
         <category>Shooter</category>
     </categories>
     <screenshots>
         <screenshot type="default">
-            <image type="source" width="1920" height="1080">
-                https://project-imprimis.github.io/www/_nuxt/img/header.6eaa8b0.png
+            <image type="source">
+                https://raw.githubusercontent.com/TheEgghead27/media/master/screenshots/header-1600x900.jpg
             </image>
-            <caption>A view from a vantage point of one of the maps available in Imprimis.</caption>
+            <caption>A view from a vantage point in map in Imprimis</caption>
         </screenshot>
         <screenshot>
-            <image type="source" width="1920" height="1080">
-                https://project-imprimis.github.io/www/_nuxt/img/1.bd2fdd7.png
-            </image>
-        </screenshot>
-        <screenshot>
-            <image type="source" width="1920" height="1080">
-                https://project-imprimis.github.io/www/_nuxt/img/2.e9a6135.png
+            <image type="source">
+                https://raw.githubusercontent.com/TheEgghead27/media/master/screenshots/1-1600x900.jpg
             </image>
         </screenshot>
         <screenshot>
-            <image type="source" width="1920" height="1080">
-                https://project-imprimis.github.io/www/_nuxt/img/3.0771c88.png
+            <image type="source">
+                https://raw.githubusercontent.com/TheEgghead27/media/master/screenshots/2-1600x900.jpg
             </image>
         </screenshot>
         <screenshot>
-            <image type="source" width="1920" height="1080">
-                https://project-imprimis.github.io/www/_nuxt/img/4.b176f4d.png
+            <image type="source">
+                https://raw.githubusercontent.com/TheEgghead27/media/master/screenshots/3-1600x900.jpg
             </image>
         </screenshot>
         <screenshot>
-            <image type="source" width="1920" height="1080">
-                https://project-imprimis.github.io/www/_nuxt/img/5.712615e.png
+            <image type="source">
+                https://raw.githubusercontent.com/TheEgghead27/media/master/screenshots/4-1600x900.jpg
+            </image>
+        </screenshot>
+        <screenshot>
+            <image type="source">
+                https://raw.githubusercontent.com/TheEgghead27/media/master/screenshots/5-1600x900.jpg
             </image>
         </screenshot>
     </screenshots>
@@ -71,7 +72,6 @@
     <url type="homepage">https://project-imprimis.org</url>
     <url type="bugtracker">https://github.com/project-imprimis/imprimis/issues</url>
     <url type="contact">https://discord.gg/WVFjtzA</url>
-    <url type="vcs-browser">https://github.com/project-imprimis/imprimis</url>
 
     <launchable type="desktop-id">org.imprimis.Imprimis.desktop</launchable>
     <provides>
@@ -106,4 +106,9 @@
             </artifacts>
         </release>
     </releases>
+
+    <content_rating type="oars-1.1">
+        <content_attribute id="violence-fantasy">moderate</content_attribute>
+        <content_attribute id="social-chat">intense</content_attribute>
+    </content_rating>
 </component>

--- a/org.imprimis.Imprimis.metainfo.xml
+++ b/org.imprimis.Imprimis.metainfo.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+	<id>org.imprimis.Imprimis</id>
+	<metadata_license>MIT <!--TODO--></metadata_license>
+	<project_license>Zlib</project_license>
+	<name>Imprimis</name>
+	<summary>Imprimis, the team based destroyable world shooter game</summary>
+	<!-- TODO
+	<description></description>
+	-->
+	<icon type="local" width="512" height="512" >/usr/share/pixmaps/imprimis.png</icon>
+	<categories>
+		<category>Game</category>
+		<category>Shooter</category>
+	</categories>
+	<!-- TODO
+	<keywords></keywords>
+	<screenshots></screenshots>
+	-->
+	<!-- tentative -->
+	<developer_name>Project Imprimis</developer_name>
+	<url type="homepage">https://project-imprimis.org</url>
+	<url type="bugtracker">https://github.com/project-imprimis/imprimis/issues</url>
+	<!-- TODO
+	<url type="faq"></url>
+	<url type="help"></url>
+	<url type="donation"></url>
+	<url type="translate"></url>
+	-->
+	<url type="contact">https://discord.gg/WVFjtzA</url>
+	<url type="vcs-browser">https://github.com/project-imprimis/imprimis</url>
+
+	<launchable type="desktop-id">org.imprimis.Imprimis.desktop</launchable>
+	<!-- TODO
+	<releases></releases>
+	-->
+	<provides>
+		<binary>imprimis</binary>
+	</provides>
+
+
+</component>

--- a/org.imprimis.Imprimis.metainfo.xml
+++ b/org.imprimis.Imprimis.metainfo.xml
@@ -1,42 +1,109 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-	<id>org.imprimis.Imprimis</id>
-	<metadata_license>MIT <!--TODO--></metadata_license>
-	<project_license>Zlib</project_license>
-	<name>Imprimis</name>
-	<summary>Imprimis, the team based destroyable world shooter game</summary>
-	<!-- TODO
-	<description></description>
-	-->
-	<icon type="local" width="512" height="512" >/usr/share/pixmaps/imprimis.png</icon>
-	<categories>
-		<category>Game</category>
-		<category>Shooter</category>
-	</categories>
-	<!-- TODO
-	<keywords></keywords>
-	<screenshots></screenshots>
-	-->
-	<!-- tentative -->
-	<developer_name>Project Imprimis</developer_name>
-	<url type="homepage">https://project-imprimis.org</url>
-	<url type="bugtracker">https://github.com/project-imprimis/imprimis/issues</url>
-	<!-- TODO
-	<url type="faq"></url>
-	<url type="help"></url>
-	<url type="donation"></url>
-	<url type="translate"></url>
-	-->
-	<url type="contact">https://discord.gg/WVFjtzA</url>
-	<url type="vcs-browser">https://github.com/project-imprimis/imprimis</url>
+    <id>org.imprimis.Imprimis</id>
+    <metadata_license>CC0-1.0</metadata_license>
+    <project_license>zlib-acknowledgement</project_license>
+    <name>Imprimis</name>
+    <summary>Imprimis, the team based destroyable world shooter game</summary>
+    <description>
+        <p>
+            A first person 3D multiplayer shooter designed around terrain modification.
+            Destroy and build the level to modify the playing field to your advantage,
+            and play against other players online using the integrated server interface.
+        </p>
+        <p>
+            Built on the fast and fully dynamic Libprimis engine, Imprimis is capable of
+            fully realtime lighting effects to go along with its realtime world modification.
+        </p>
+        <p>
+            Fully open source with 100% permissively licensed assets.
+        </p>
 
-	<launchable type="desktop-id">org.imprimis.Imprimis.desktop</launchable>
-	<!-- TODO
-	<releases></releases>
-	-->
-	<provides>
-		<binary>imprimis</binary>
-	</provides>
+        <p>
+            This game is in an alpha state and releases stable monthly snapshots with more
+            verification than the nightly edge builds.
+        </p>
 
+        <p>
+            Multiplayer playtests are conducted at 1 PM PDT/ 4 PM EDT/ 10 PM CEST
+            on Sundays weekly, for a chance to play with other players and developers.
+        </p>
+    </description>
+    <icon type="local" width="512" height="512">/usr/share/pixmaps/imprimis.png</icon>
+    <categories>
+        <category>Game</category>
+        <category>Shooter</category>
+    </categories>
+    <screenshots>
+        <screenshot type="default">
+            <image type="source" width="1920" height="1080">
+                https://project-imprimis.github.io/www/_nuxt/img/header.6eaa8b0.png
+            </image>
+            <caption>A view from a vantage point of one of the maps available in Imprimis.</caption>
+        </screenshot>
+        <screenshot>
+            <image type="source" width="1920" height="1080">
+                https://project-imprimis.github.io/www/_nuxt/img/1.bd2fdd7.png
+            </image>
+        </screenshot>
+        <screenshot>
+            <image type="source" width="1920" height="1080">
+                https://project-imprimis.github.io/www/_nuxt/img/2.e9a6135.png
+            </image>
+        </screenshot>
+        <screenshot>
+            <image type="source" width="1920" height="1080">
+                https://project-imprimis.github.io/www/_nuxt/img/3.0771c88.png
+            </image>
+        </screenshot>
+        <screenshot>
+            <image type="source" width="1920" height="1080">
+                https://project-imprimis.github.io/www/_nuxt/img/4.b176f4d.png
+            </image>
+        </screenshot>
+        <screenshot>
+            <image type="source" width="1920" height="1080">
+                https://project-imprimis.github.io/www/_nuxt/img/5.712615e.png
+            </image>
+        </screenshot>
+    </screenshots>
+    <developer_name>Project Imprimis</developer_name>
+    <url type="homepage">https://project-imprimis.org</url>
+    <url type="bugtracker">https://github.com/project-imprimis/imprimis/issues</url>
+    <url type="contact">https://discord.gg/WVFjtzA</url>
+    <url type="vcs-browser">https://github.com/project-imprimis/imprimis</url>
 
+    <launchable type="desktop-id">org.imprimis.Imprimis.desktop</launchable>
+    <provides>
+        <binary>imprimis</binary>
+    </provides>
+
+    <releases>
+        <release version="0.19a" date="2022-07-01" date_eol="2022-08-01" urgency="critical">
+            <description>
+                <p>Alpha 19 "Snoqualmie" - The nineteenth alpha release of Imprimis.</p>
+            </description>
+            <url>
+                https://github.com/project-imprimis/imprimis/releases/tag/v0.19a
+            </url>
+            <artifacts>
+                <artifact type="binary" platform="x86_64-linux-gnu">
+                    <location>
+                        https://github.com/project-imprimis/imprimis/releases/download/v0.19a/imprimis-linux-ubuntu.zip
+                    </location>
+                    <checksum type="sha256">
+                        f2f6f3a6435607b3a979d2f68722cfa33ad7311b303fa42561cd8b5eaf367ac2
+                    </checksum>
+                </artifact>
+                <artifact type="binary" platform="x86_64-windows-msvc">
+                    <location>
+                        https://github.com/project-imprimis/imprimis/releases/download/v0.19a/imprimis-linux-ubuntu.zip
+                    </location>
+                    <checksum type="sha256">
+                        3d10202ebd39eb5143845b3646a5c926ebbf308174003835a4c8299266acf65c
+                    </checksum>
+                </artifact>
+            </artifacts>
+        </release>
+    </releases>
 </component>


### PR DESCRIPTION
This pull request adds support for the `DESTDIR` and `PREFIX` environment variables commonly used in packaging systems to build system images. Further, it allows for some of the `CXXFLAG`s to be overridden with the settings preferred by the environment.
Further, an `uninstall` makefile target was added to remove an installation.
The .desktop and .metainfo.xml files were added to provide FreeDesktop metadata, which can be installed systemwide for integration with desktop environments, while also being used in the Flatpak for its store pages and launcher interface.