### PR TITLE
Fix demo gun message size bug in edit mode.

### DIFF
--- a/game/gameclient.cpp
+++ b/game/gameclient.cpp
@@ -817,7 +817,6 @@ namespace game
             case Edit_Copy:
             case Edit_Paste:
             case Edit_DelCube:
-            case Edit_AddCube:
             {
                 switch(op)
                 {
@@ -843,6 +842,7 @@ namespace game
                    sel.corner);               //13
                 break;
             }
+            case Edit_AddCube:
             case Edit_Rotate:
             {
                 addmsg(NetMsg_EditFace + op, "ri9i5",


### PR DESCRIPTION
Firing the demo gun stopped the game because of an inconsistent message
size.

This commit fixes that so firing does not crash the game.

https://user-images.githubusercontent.com/48164786/184238523-9f6080a9-42b8-43ac-8931-451d9eb19959.mp4


