### PR TITLE
Update CI dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - name: Checkout flatpak build templates
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: project-imprimis/org.imprimis.Imprimis.flatpak
         submodules: true

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -49,7 +49,7 @@ jobs:
       run: flatpak build-bundle ./local imprimis.flatpak org.imprimis.Imprimis
     
     - name: Upload build artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: imprimis-flatpak
         path: ./imprimis.flatpak

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -19,7 +19,7 @@ jobs:
       run: sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libglew-dev
       
     - name: Download libprimis.lib artifact
-      uses: dawidd6/action-download-artifact@v2.18.0
+      uses: dawidd6/action-download-artifact@v3.0.0
       with:
         workflow: makefile.yml
         name: libprimis-linux

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true
 

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -37,7 +37,7 @@ jobs:
       run: make remove-build-files
     
     - name: Upload build artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: imprimis-linux
         path: ./*

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Clone repository and submodules
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: true
 

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -40,7 +40,7 @@ jobs:
         scoop install nsis
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.3.1
 
 #     afaik this isnt necessary
 #    - name: Restore NuGet packages

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -22,7 +22,7 @@ jobs:
         submodules: true
 
     - name: Download libprimis.lib artifact
-      uses: dawidd6/action-download-artifact@v2.18.0
+      uses: dawidd6/action-download-artifact@v3.0.0
       with:
         workflow: msbuild.yml
         name: libprimis-windows

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -57,7 +57,7 @@ jobs:
       run: makensis ./vcpp/imprimis.nsi
 
     - name: Upload Imprimis Windows binary artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: imprimis-windows
         path: |
@@ -69,7 +69,7 @@ jobs:
           ./media/
 
     - name: Upload Imprimis Windows installer
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: imprimis-windows-installer
         path: ./vcpp/imprimis_windows.exe


### PR DESCRIPTION
Adds Dependabot update notifications for GitHub Action dependencies, and updates existing dependencies.

`dawidd6/action-download-artifact` is still kept as a dependency due to the unusual requirement that we specify a GH Actions run id in order to target the right libprimis artifact (https://github.com/actions/download-artifact/issues/229 may be related, and is still an issue).